### PR TITLE
Update beneficiary retrieval comments

### DIFF
--- a/src/main/java/mx/edu/uacm/is/slt/as/sistemapolizas/extern/PolizaExternalClient.java
+++ b/src/main/java/mx/edu/uacm/is/slt/as/sistemapolizas/extern/PolizaExternalClient.java
@@ -64,7 +64,8 @@ public class PolizaExternalClient {
                 .block();
     }
 
-    // devuelve todos los beneficiarios de una póliza - Revisar
+    // Obtiene todos los beneficiarios de la póliza. Las respuestas HTTP 4xx
+    // se transforman en una lista vacía en lugar de provocar una excepción.
     public List<BeneficiarioDTO> obtenerBeneficiarios(UUID clave) {
         return web.get()
                 .uri("/poliza/{clave}/beneficiarios", clave)
@@ -76,7 +77,8 @@ public class PolizaExternalClient {
                 .block();
     }
 
-    //  devuelve todos los beneficiarios de una póliza o lista vacía si la ruta retorna 404 - asi no
+    // Obtiene todos los beneficiarios de la póliza sin interceptar las respuestas
+    // 4xx; cualquier error de este tipo se propaga como excepción.
     public List<BeneficiarioDTO> obtenerBeneficiariosPorPoliza(UUID clavePoliza) {
         return web.get()
                 .uri("/beneficiarios/{clave}", clavePoliza)   // una sola variable


### PR DESCRIPTION
## Summary
- clarify that `obtenerBeneficiarios` converts 4xx responses to an empty list
- clarify that `obtenerBeneficiariosPorPoliza` does not convert 4xx responses

## Testing
- `./mvnw -q test` *(fails: unable to fetch Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685e1091fe14832faac524dad9760adf