### PR TITLE
Use logger in StartupSyncRunner

### DIFF
--- a/src/main/java/mx/edu/uacm/is/slt/as/sistemapolizas/config/StartupSyncRunner.java
+++ b/src/main/java/mx/edu/uacm/is/slt/as/sistemapolizas/config/StartupSyncRunner.java
@@ -3,6 +3,8 @@ package mx.edu.uacm.is.slt.as.sistemapolizas.config;
 import mx.edu.uacm.is.slt.as.sistemapolizas.service.SincronizacionService;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.stereotype.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import lombok.RequiredArgsConstructor;
 
 
@@ -11,10 +13,11 @@ import lombok.RequiredArgsConstructor;
 public class StartupSyncRunner implements CommandLineRunner{
 
     private final SincronizacionService sync;
+    private static final Logger log = LoggerFactory.getLogger(StartupSyncRunner.class);
 
     @Override
     public void run(String... args) {
         sync.sincronizarTodo();
-        System.out.println("✅ BD local sincronizada con el sistema dueño");
+        log.info("✅ BD local sincronizada con el sistema dueño");
     }
 }


### PR DESCRIPTION
## Summary
- replace console output with SLF4J logger in `StartupSyncRunner`
- add logger imports

## Testing
- `mvn -q -e -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e19fa4c98832f98b98a1e2cd2fef3