### PR TITLE
Make WebClient base URL configurable

### DIFF
--- a/src/main/java/mx/edu/uacm/is/slt/as/sistemapolizas/config/WebClientConfig.java
+++ b/src/main/java/mx/edu/uacm/is/slt/as/sistemapolizas/config/WebClientConfig.java
@@ -1,5 +1,6 @@
 package mx.edu.uacm.is.slt.as.sistemapolizas.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -7,7 +8,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 @Configuration
 public class WebClientConfig {
     @Bean
-    WebClient polizaWebClient() {
-        return WebClient.builder().baseUrl("http://nachintoch.mx:8080").build();
+    WebClient polizaWebClient(@Value("${remote.base-url}") String baseUrl) {
+        return WebClient.builder().baseUrl(baseUrl).build();
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,3 +13,5 @@ spring.datasource.password=uacm123
 
 logging.level.org.hibernate.SQL=DEBUG
 logging.level.org.springframework.web.reactive.function.client.ExchangeFunctions=DEBUG
+remote.base-url=http://nachintoch.mx:8080
+

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -6,3 +6,6 @@ spring.datasource.password=
 
 # Que Hibernate auto-cree el esquema en cada arranque de test
 spring.jpa.hibernate.ddl-auto=create-drop
+
+# Base URL for WebClient used in integration tests
+remote.base-url=http://nachintoch.mx:8080


### PR DESCRIPTION
## Summary
- add `remote.base-url` property to `application.properties`
- inject `remote.base-url` into `WebClientConfig` and use it for WebClient setup

## Testing
- `./mvnw -q test` *(fails: Failed to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685e19fb7c70832f882ad697d153b5b8