### PR TITLE
Implement remote CRUD operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ La aplicación queda disponible en `http://localhost:8080`.
 Al iniciar, el servicio ejecuta una sincronización automática con un sistema
 remoto configurado mediante la propiedad `remote.base-url` en
 `application.properties`.
+Las operaciones de creación y actualización de datos se envían también al sistema remoto mediante el servicio de sincronización.
 
 ## Uso básico del API
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ java -jar target/sistpolizas-0.0.1-SNAPSHOT.jar
 
 La aplicación queda disponible en `http://localhost:8080`.
 
+Al iniciar, el servicio ejecuta una sincronización automática con un sistema
+remoto configurado mediante la propiedad `remote.base-url` en
+`application.properties`.
+
 ## Uso básico del API
 
 Algunos ejemplos de los puntos de entrada REST:

--- a/SuggestedTasks.md
+++ b/SuggestedTasks.md
@@ -1,0 +1,26 @@
+# Suggested Tasks
+
+A continuación se listan las tareas pendientes para completar la funcionalidad del proyecto.
+
+1. **Servicio de Sincronización**
+   - Completar `SincronizacionService.sincronizarTodo()` para traer pólizas, clientes y beneficiarios del sistema remoto y reflejarlos en la base local.
+   - Manejar fallos de comunicación con el servicio remoto.
+
+2. **Operaciones CRUD sincronizadas**
+   - Implementar métodos en `SincronizacionService` para crear, actualizar y eliminar clientes, pólizas y beneficiarios tanto de forma local como remota.
+   - Extender `PolizaExternalClient` con las llamadas HTTP correspondientes.
+
+3. **Controladores y Servicios Locales**
+   - Ajustar controladores y servicios para usar la lógica de sincronización al modificar datos.
+   - Garantizar coherencia entre la base local y el sistema externo.
+
+4. **Pruebas**
+   - Añadir pruebas unitarias e integrales que cubran controladores y la sincronización.
+   - Utilizar la configuración H2 incluida para las pruebas.
+
+5. **Documentación**
+   - Actualizar `README.md` con la explicación de la sincronización y los pasos para ejecutar la aplicación junto con el sistema remoto.
+
+6. **Consideraciones adicionales**
+   - Respetar las rutas del sistema remoto para las operaciones de clientes, pólizas y beneficiarios.
+   - Revisar si existen rutas para actualizar o eliminar beneficiarios en el sistema externo y, de ser así, implementarlas.

--- a/src/main/java/mx/edu/uacm/is/slt/as/sistemapolizas/extern/PolizaExternalClient.java
+++ b/src/main/java/mx/edu/uacm/is/slt/as/sistemapolizas/extern/PolizaExternalClient.java
@@ -22,10 +22,78 @@ public class PolizaExternalClient {
     @Qualifier("polizaWebClient")
     private final WebClient web;
 
+    // ---- Operaciones remotas de escritura ----
+
+    public void crearPolizaRemota(PolizaDTO dto) {
+        String path = String.format(
+                "/poliza/%s/%d/%.2f/%s/%s",
+                dto.clave(), dto.tipo(), dto.monto(), dto.descripcion(), dto.curpCliente()
+        );
+        web.post()
+                .uri(path)
+                .retrieve()
+                .toBodilessEntity()
+                .block();
+    }
+
     public void actualizarPolizaRemota(PolizaDTO dto) {
+        String path = String.format(
+                "/poliza/%s/%d/%.2f/%s/%s",
+                dto.clave(), dto.tipo(), dto.monto(), dto.descripcion(), dto.curpCliente()
+        );
         web.put()
-                .uri("/{clave}", dto.clave())
-                .bodyValue(dto)
+                .uri(path)
+                .retrieve()
+                .toBodilessEntity()
+                .block();
+    }
+
+    public void crearClienteRemoto(ClienteDTO dto) {
+        String base = String.format(
+                "/cliente/%s/%s/%s/%s/%s",
+                dto.curp(), dto.direccion(), dto.fechaNacimiento().toLocalDate(),
+                dto.nombres(), dto.primerApellido()
+        );
+        if (dto.segundoApellido() != null) {
+            base += "/" + dto.segundoApellido();
+        }
+        web.post()
+                .uri(base)
+                .retrieve()
+                .toBodilessEntity()
+                .block();
+    }
+
+    public void actualizarClienteRemoto(ClienteDTO dto) {
+        String base = String.format(
+                "/cliente/%s/%s/%s/%s/%s",
+                dto.curp(), dto.direccion(), dto.fechaNacimiento().toLocalDate(),
+                dto.nombres(), dto.primerApellido()
+        );
+        if (dto.segundoApellido() != null) {
+            base += "/" + dto.segundoApellido();
+        }
+        web.put()
+                .uri(base)
+                .retrieve()
+                .toBodilessEntity()
+                .block();
+    }
+
+    public void crearBeneficiarioRemoto(UUID clavePoliza, BeneficiarioDTO dto) {
+        String base = String.format(
+                "/beneficiario/%s/%s/%d/%s/%s",
+                dto.fechaNacimiento().toLocalDate(),
+                clavePoliza,
+                dto.porcentaje(),
+                dto.nombres(),
+                dto.primerApellido()
+        );
+        if (dto.segundoApellido() != null) {
+            base += "/" + dto.segundoApellido();
+        }
+        web.post()
+                .uri(base)
                 .retrieve()
                 .toBodilessEntity()
                 .block();

--- a/src/main/java/mx/edu/uacm/is/slt/as/sistemapolizas/mapper/BeneficiarioMapper.java
+++ b/src/main/java/mx/edu/uacm/is/slt/as/sistemapolizas/mapper/BeneficiarioMapper.java
@@ -17,4 +17,15 @@ public interface BeneficiarioMapper {
         );
         return new BeneficiarioPoliza(id, dto.porcentaje());
     }
+
+    static BeneficiarioDTO toDto(BeneficiarioPoliza entity) {
+        BeneficiarioPolizaId id = entity.getId();
+        return new BeneficiarioDTO(
+                id.getNombres(),
+                id.getPrimerApellido(),
+                id.getSegundoApellido(),
+                id.getFechaNacimiento().atStartOfDay().atOffset(java.time.ZoneOffset.UTC),
+                entity.getPorcentaje()
+        );
+    }
 }

--- a/src/main/java/mx/edu/uacm/is/slt/as/sistemapolizas/mapper/ClienteMapper.java
+++ b/src/main/java/mx/edu/uacm/is/slt/as/sistemapolizas/mapper/ClienteMapper.java
@@ -14,4 +14,15 @@ public interface ClienteMapper {
                 dto.fechaNacimiento().toLocalDate()
         );
     }
+
+    static ClienteDTO toDto(Cliente entity) {
+        return new ClienteDTO(
+                entity.getCurp(),
+                entity.getNombres(),
+                entity.getPrimerApellido(),
+                entity.getSegundoApellido(),
+                entity.getDireccion(),
+                entity.getFechaNacimiento().atStartOfDay().atOffset(java.time.ZoneOffset.UTC)
+        );
+    }
 }

--- a/src/main/java/mx/edu/uacm/is/slt/as/sistemapolizas/service/BeneficiarioPolizaService.java
+++ b/src/main/java/mx/edu/uacm/is/slt/as/sistemapolizas/service/BeneficiarioPolizaService.java
@@ -3,22 +3,19 @@ package mx.edu.uacm.is.slt.as.sistemapolizas.service;
 import mx.edu.uacm.is.slt.as.sistemapolizas.model.BeneficiarioPoliza;
 import mx.edu.uacm.is.slt.as.sistemapolizas.model.BeneficiarioPolizaId;
 import mx.edu.uacm.is.slt.as.sistemapolizas.repository.BeneficiarioPolizaRepository;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import lombok.RequiredArgsConstructor;
 
 import java.util.List;
 import java.util.Optional;
 
 @Service
+@RequiredArgsConstructor
 public class BeneficiarioPolizaService {
 
     private final BeneficiarioPolizaRepository repository;
-
-    @Autowired
-    public BeneficiarioPolizaService(BeneficiarioPolizaRepository repository) {
-        this.repository = repository;
-    }
+    private final SincronizacionService syncService;
 
     public List<BeneficiarioPoliza> buscarTodos() {
         return repository.findAll();
@@ -30,7 +27,7 @@ public class BeneficiarioPolizaService {
 
     @Transactional
     public BeneficiarioPoliza guardar(BeneficiarioPoliza nuevo) {
-        return repository.save(nuevo);
+        return syncService.crearBeneficiarioLocal(nuevo);
     }
 
     @Transactional
@@ -39,14 +36,14 @@ public class BeneficiarioPolizaService {
         return repository.findById(id)
                 .map(existing -> {
                     existing.setPorcentaje(actualizado.getPorcentaje());
-                    return repository.save(existing);
+                    return syncService.actualizarBeneficiarioLocal(existing);
                 });
     }
 
     @Transactional
     public boolean eliminarPorId(BeneficiarioPolizaId id) {
         if (repository.existsById(id)) {
-            repository.deleteById(id);
+            syncService.eliminarBeneficiarioLocal(id);
             return true;
         }
         return false;

--- a/src/main/java/mx/edu/uacm/is/slt/as/sistemapolizas/service/ClienteService.java
+++ b/src/main/java/mx/edu/uacm/is/slt/as/sistemapolizas/service/ClienteService.java
@@ -2,21 +2,18 @@ package mx.edu.uacm.is.slt.as.sistemapolizas.service;
 
 import mx.edu.uacm.is.slt.as.sistemapolizas.model.Cliente;
 import mx.edu.uacm.is.slt.as.sistemapolizas.repository.ClienteRepository;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import lombok.RequiredArgsConstructor;
 
 import java.util.List;
 import java.util.Optional;
 
 @Service
+@RequiredArgsConstructor
 public class ClienteService {
 
     private final ClienteRepository clienteRepository;
-
-    @Autowired
-    public ClienteService(ClienteRepository clienteRepository) {
-        this.clienteRepository = clienteRepository;
-    }
+    private final SincronizacionService syncService;
 
     // listar todos los clientes
     public List<Cliente> buscarTodos() {
@@ -30,7 +27,7 @@ public class ClienteService {
 
     // crear o guardar un cliente
     public Cliente guardar(Cliente nuevo) {
-        return clienteRepository.save(nuevo);
+        return syncService.crearClienteLocal(nuevo);
     }
 
     // actualizar un cliente existente
@@ -43,14 +40,14 @@ public class ClienteService {
                     existing.setDireccion(datosActualizados.getDireccion());
                     existing.setFechaNacimiento(datosActualizados.getFechaNacimiento());
 
-                    return clienteRepository.save(existing);
+                    return syncService.actualizarClienteLocal(existing);
                 });
     }
 
     // eliminar un cliente por CURP
     public boolean eliminarPorCurp(String curp) {
         if (clienteRepository.existsById(curp)) {
-            clienteRepository.deleteById(curp);
+            syncService.eliminarClienteLocal(curp);
             return true;
         }
         return false;

--- a/src/main/java/mx/edu/uacm/is/slt/as/sistemapolizas/service/SincronizacionService.java
+++ b/src/main/java/mx/edu/uacm/is/slt/as/sistemapolizas/service/SincronizacionService.java
@@ -12,6 +12,7 @@ import mx.edu.uacm.is.slt.as.sistemapolizas.mapper.PolizaMapper;
 import mx.edu.uacm.is.slt.as.sistemapolizas.model.Poliza;
 import mx.edu.uacm.is.slt.as.sistemapolizas.model.Cliente;
 import mx.edu.uacm.is.slt.as.sistemapolizas.model.BeneficiarioPoliza;
+import mx.edu.uacm.is.slt.as.sistemapolizas.model.BeneficiarioPolizaId;
 import mx.edu.uacm.is.slt.as.sistemapolizas.repository.BeneficiarioPolizaRepository;
 import mx.edu.uacm.is.slt.as.sistemapolizas.repository.ClienteRepository;
 import mx.edu.uacm.is.slt.as.sistemapolizas.repository.PolizaRepository;
@@ -132,6 +133,17 @@ public class SincronizacionService {
         external.crearBeneficiarioRemoto(nuevo.getId().getClavePoliza(),
                 BeneficiarioMapper.toDto(guardado));
         return guardado;
+    }
+
+    public BeneficiarioPoliza actualizarBeneficiarioLocal(BeneficiarioPoliza actualizado) {
+        BeneficiarioPoliza guardado = beneficiarioRepo.save(actualizado);
+        // no existe endpoint para actualizar beneficiarios en el sistema remoto
+        return guardado;
+    }
+
+    public void eliminarBeneficiarioLocal(BeneficiarioPolizaId id) {
+        beneficiarioRepo.deleteById(id);
+        // no existe endpoint para borrar beneficiarios en el sistema remoto
     }
 
 }

--- a/src/main/java/mx/edu/uacm/is/slt/as/sistemapolizas/service/SincronizacionService.java
+++ b/src/main/java/mx/edu/uacm/is/slt/as/sistemapolizas/service/SincronizacionService.java
@@ -4,10 +4,14 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import mx.edu.uacm.is.slt.as.sistemapolizas.dto.ClienteDTO;
 import mx.edu.uacm.is.slt.as.sistemapolizas.dto.PolizaDTO;
+import mx.edu.uacm.is.slt.as.sistemapolizas.dto.BeneficiarioDTO;
 import mx.edu.uacm.is.slt.as.sistemapolizas.extern.PolizaExternalClient;
 import mx.edu.uacm.is.slt.as.sistemapolizas.mapper.ClienteMapper;
+import mx.edu.uacm.is.slt.as.sistemapolizas.mapper.BeneficiarioMapper;
 import mx.edu.uacm.is.slt.as.sistemapolizas.mapper.PolizaMapper;
 import mx.edu.uacm.is.slt.as.sistemapolizas.model.Poliza;
+import mx.edu.uacm.is.slt.as.sistemapolizas.model.Cliente;
+import mx.edu.uacm.is.slt.as.sistemapolizas.model.BeneficiarioPoliza;
 import mx.edu.uacm.is.slt.as.sistemapolizas.repository.BeneficiarioPolizaRepository;
 import mx.edu.uacm.is.slt.as.sistemapolizas.repository.ClienteRepository;
 import mx.edu.uacm.is.slt.as.sistemapolizas.repository.PolizaRepository;
@@ -39,44 +43,95 @@ public class SincronizacionService {
      */
     @Transactional
     public void sincronizarTodo() {            // en StartupSync se llama
-        List<PolizaDTO> remotas = external.obtenerTodasLasPolizas();
+        List<PolizaDTO> remotas;
+        try {
+            remotas = external.obtenerTodasLasPolizas();
+        } catch (Exception e) {
+            // si la comunicación falla no hacemos nada
+            return;
+        }
 
         for (PolizaDTO pDto : remotas) {
-            // clientes
-            ClienteDTO cDto = external.obtenerCliente(pDto.curpCliente());
-            clienteRepo.save(ClienteMapper.toEntity(cDto));
-            // pólizas
-            Poliza polizaLocal = PolizaMapper.toEntity(pDto);
-            polizaRepo.save(polizaLocal);
+            try {
+                // clientes
+                ClienteDTO cDto = external.obtenerCliente(pDto.curpCliente());
+                if (cDto != null) {
+                    clienteRepo.save(ClienteMapper.toEntity(cDto));
+                }
 
-            // aqui beneficiarios
+                // pólizas
+                Poliza polizaLocal = PolizaMapper.toEntity(pDto);
+                polizaRepo.save(polizaLocal);
+
+                // beneficiarios
+                beneficiarioRepo.deleteAllByIdClavePoliza(pDto.clave());
+                List<BeneficiarioDTO> beneficiarios = external.obtenerBeneficiarios(pDto.clave());
+                for (BeneficiarioDTO bDto : beneficiarios) {
+                    BeneficiarioPoliza b = BeneficiarioMapper.toEntity(bDto, pDto.clave());
+                    beneficiarioRepo.save(b);
+                }
+            } catch (Exception ex) {
+                // errores individuales se ignoran para continuar con el resto
+            }
         }
     }
 
 
-    /** cuando en la BD local se crea o actualiza una póliza este
-     * método debe llamarse para propagar el cambio al sistema remoto */
-    public Poliza crearOActualizarPolizaLocal(Poliza entidadLocal) {
-        // guardo local
-        Poliza guardada = polizaRepo.save(entidadLocal);
-
-        // actualiza/crea en remoto
-        PolizaDTO dto = PolizaMapper.toDto(guardada);
-        // si falla, puedes manejar excepción
-        external.actualizarPolizaRemota(dto);
+    /**
+     * Crea una póliza local y también la registra en el sistema remoto.
+     */
+    public Poliza crearPolizaLocal(Poliza nueva) {
+        Poliza guardada = polizaRepo.save(nueva);
+        external.crearPolizaRemota(PolizaMapper.toDto(guardada));
         return guardada;
     }
 
-    // lo mismo para eliminar
-    public void eliminarPolizaLocal(UUID clave) {
-        // borra en local
-        polizaRepo.deleteById(clave);
+    /**
+     * Actualiza una póliza local y refleja el cambio en el sistema remoto.
+     */
+    public Poliza actualizarPolizaLocal(Poliza actualizada) {
+        Poliza guardada = polizaRepo.save(actualizada);
+        external.actualizarPolizaRemota(PolizaMapper.toDto(guardada));
+        return guardada;
+    }
 
-        // borra en remoto
+    // compatibilidad con código existente
+    public Poliza crearOActualizarPolizaLocal(Poliza p) {
+        return actualizarPolizaLocal(p);
+    }
+
+    // eliminar póliza local y en remoto
+    public void eliminarPolizaLocal(UUID clave) {
+        polizaRepo.deleteById(clave);
         external.eliminarPolizaRemota(clave);
     }
 
-    // hacer de crear/actualizar/eliminar cliente local y remoto
-    // también hacer de beneficiarios local y remoto
+    // ---- operaciones para clientes ----
+
+    public Cliente crearClienteLocal(Cliente nuevo) {
+        Cliente guardado = clienteRepo.save(nuevo);
+        external.crearClienteRemoto(ClienteMapper.toDto(guardado));
+        return guardado;
+    }
+
+    public Cliente actualizarClienteLocal(Cliente actualizado) {
+        Cliente guardado = clienteRepo.save(actualizado);
+        external.actualizarClienteRemoto(ClienteMapper.toDto(guardado));
+        return guardado;
+    }
+
+    public void eliminarClienteLocal(String curp) {
+        clienteRepo.deleteById(curp);
+        // si hubiera end-point para borrar en remoto se llamaría aquí
+    }
+
+    // ---- operaciones para beneficiarios ----
+
+    public BeneficiarioPoliza crearBeneficiarioLocal(BeneficiarioPoliza nuevo) {
+        BeneficiarioPoliza guardado = beneficiarioRepo.save(nuevo);
+        external.crearBeneficiarioRemoto(nuevo.getId().getClavePoliza(),
+                BeneficiarioMapper.toDto(guardado));
+        return guardado;
+    }
 
 }


### PR DESCRIPTION
## Summary
- add DTO mappers to convert local entities back to DTOs
- extend `PolizaExternalClient` with POST/PUT endpoints for policies, clients and beneficiaries
- provide synchronized CRUD helpers in `SincronizacionService`

## Testing
- `bash ./mvnw -q test` *(fails: repo.maven.apache.org blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685f919af26c832fa6c1a7e79ea79d39